### PR TITLE
feat: P³ DuckDB integration — dqm tables + smart default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# data-quality-llm
+
+Data quality checks for DuckDB databases, powered by Claude.
+
+## Installation
+
+```bash
+uv sync
+```
+
+## Usage
+
+```bash
+# List tables in the default P³ database
+uv run dqm tables
+
+# Use a custom database
+uv run dqm --db /path/to/other.duckdb tables
+
+# Generate a Markdown report for a table
+uv run dqm report episodes
+uv run dqm report episodes --output report.md
+```
+
+## Default data source
+
+The tool defaults to the P³ (parakeet-podcast-processor) DuckDB, checking these paths in order:
+
+1. `~/.p3/p3.duckdb`
+2. `~/Code/parakeet-podcast-processor/data/p3.duckdb`
+
+Override with `--db <path>`.
+
+## P³ columns worth monitoring
+
+| Table | Column | Why |
+|-------|--------|-----|
+| `episodes` | `title` | Null spike → feed ingestion broken |
+| `episodes` | `published_at` | Null or future date → parser regression |
+| `summaries` | `body` | Null spike → LLM summariser failing |
+| `summaries` | `model` | Cardinality drop → model switch / rollback |
+| `transcripts` | `text` | Null or very short → Whisper pipeline error |
+| `transcripts` | `duration_s` | Outliers → bad audio or wrong episode matched |
+| `errors` | `error_type` | Cardinality spike → new failure mode |
+| `errors` | `created_at` | Volume spike → systemic processing failure |

--- a/dqm/cli.py
+++ b/dqm/cli.py
@@ -1,24 +1,47 @@
 """CLI entrypoint for dqm."""
 
 import click
-import sys
 from pathlib import Path
 
-DEFAULT_DB = Path.home() / ".p3" / "p3.duckdb"
+from .db import resolve_default_db
 
 
 @click.group()
 @click.option(
     "--db",
-    default=str(DEFAULT_DB),
-    show_default=True,
-    help="Path to DuckDB database file.",
+    default=None,
+    show_default=False,
+    help="Path to DuckDB database file. Defaults to ~/.p3/p3.duckdb.",
 )
 @click.pass_context
-def cli(ctx: click.Context, db: str) -> None:
+def cli(ctx: click.Context, db: str | None) -> None:
     """Data quality checks for DuckDB databases, powered by Claude."""
     ctx.ensure_object(dict)
-    ctx.obj["db"] = db
+    ctx.obj["db"] = db or resolve_default_db()
+
+
+@cli.command("tables")
+@click.pass_context
+def tables_cmd(ctx: click.Context) -> None:
+    """List all tables in the connected database."""
+    from rich.console import Console
+    from rich.table import Table
+    from .db import list_tables
+
+    db_path = ctx.obj["db"]
+    console = Console()
+
+    try:
+        names = list_tables(db_path)
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+
+    table = Table(title=f"Tables in {db_path}", show_header=True)
+    table.add_column("Table", style="cyan")
+    for name in names:
+        table.add_row(name)
+    console.print(table)
 
 
 @cli.command()
@@ -28,10 +51,10 @@ def cli(ctx: click.Context, db: str) -> None:
 def report(ctx: click.Context, table: str, output: str | None) -> None:
     """Generate a Markdown data quality report for TABLE."""
     from datetime import datetime, timezone
-    from .models import Anomaly, ColumnDiff, TableDiff
+    from .models import ColumnDiff, TableDiff
     from .report import ReportGenerator
 
-    # Placeholder diff — real data comes from snapshot store (issue #6) and diff engine (issue #7)
+    # Placeholder diff — real data comes from snapshot store (#6) and diff engine (#7)
     now = datetime.now(tz=timezone.utc)
     diff = TableDiff(
         table=table,

--- a/dqm/db.py
+++ b/dqm/db.py
@@ -1,0 +1,38 @@
+"""DuckDB connection helper."""
+
+from pathlib import Path
+
+import duckdb
+
+# Candidate paths for the P³ podcast-processor database, in priority order.
+_P3_CANDIDATES = [
+    Path.home() / ".p3" / "p3.duckdb",
+    Path.home() / "Code" / "parakeet-podcast-processor" / "data" / "p3.duckdb",
+]
+
+
+def resolve_default_db() -> str:
+    """Return the first existing P³ DB path, or the primary candidate as a default."""
+    for path in _P3_CANDIDATES:
+        if path.exists():
+            return str(path)
+    return str(_P3_CANDIDATES[0])
+
+
+def connect(db_path: str) -> duckdb.DuckDBPyConnection:
+    """Open a read-only DuckDB connection, raising a clear error if the file is missing."""
+    path = Path(db_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Database not found: {db_path}\n"
+            "Pass --db <path> or set up the P³ DB at ~/.p3/p3.duckdb"
+        )
+    return duckdb.connect(str(path), read_only=True)
+
+
+def list_tables(db_path: str) -> list[str]:
+    """Return sorted table names in the database."""
+    con = connect(db_path)
+    rows = con.execute("SHOW TABLES").fetchall()
+    con.close()
+    return sorted(row[0] for row in rows)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,62 @@
+"""Tests for dqm.db — uses a real temporary DuckDB file."""
+
+import pytest
+import duckdb
+from pathlib import Path
+
+from dqm.db import connect, list_tables, resolve_default_db
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    db_file = tmp_path / "test.duckdb"
+    con = duckdb.connect(str(db_file))
+    con.execute("CREATE TABLE episodes (id INTEGER, title VARCHAR)")
+    con.execute("CREATE TABLE summaries (id INTEGER, body VARCHAR)")
+    con.close()
+    return str(db_file)
+
+
+def test_connect_returns_connection(tmp_db):
+    con = connect(tmp_db)
+    assert con is not None
+    con.close()
+
+
+def test_connect_missing_file_raises():
+    with pytest.raises(FileNotFoundError, match="Database not found"):
+        connect("/nonexistent/path/db.duckdb")
+
+
+def test_list_tables_returns_sorted(tmp_db):
+    tables = list_tables(tmp_db)
+    assert tables == ["episodes", "summaries"]
+
+
+def test_list_tables_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        list_tables("/nonexistent/path/db.duckdb")
+
+
+def test_resolve_default_db_returns_string():
+    result = resolve_default_db()
+    assert isinstance(result, str)
+    assert result.endswith(".duckdb")
+
+
+def test_resolve_default_db_prefers_existing(tmp_path, monkeypatch):
+    """If one candidate exists, it should be returned first."""
+    db_file = tmp_path / "p3.duckdb"
+    db_file.touch()
+
+    import dqm.db as db_module
+    monkeypatch.setattr(db_module, "_P3_CANDIDATES", [db_file, Path("/nonexistent/p3.duckdb")])
+    assert resolve_default_db() == str(db_file)
+
+
+def test_resolve_default_db_fallback_to_first_candidate(monkeypatch):
+    """If no candidate exists, return the first candidate path."""
+    import dqm.db as db_module
+    candidates = [Path("/missing/a.duckdb"), Path("/missing/b.duckdb")]
+    monkeypatch.setattr(db_module, "_P3_CANDIDATES", candidates)
+    assert resolve_default_db() == str(candidates[0])


### PR DESCRIPTION
## Summary
- `dqm/db.py` — `connect()`, `list_tables()`, `resolve_default_db()` with two P³ candidate paths
- Default DB resolved at runtime: prefers first existing candidate (`~/.p3/p3.duckdb` then `~/Code/parakeet-podcast-processor/data/p3.duckdb`)
- `dqm tables` — lists all tables in the connected DB via Rich formatted output
- Clear `FileNotFoundError` with hint when DB is missing
- README updated: installation, usage, default source explanation, P³ columns worth monitoring

## Test plan
- [x] `uv run pytest tests/` — 27/27 passing
- [x] `uv run dqm tables --help` works
- [x] Smart path resolution tested with `monkeypatch`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)