### PR TITLE
feat: column profiler — nulls, cardinality, min/max, distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,31 @@ uv run dqm tables
 # Use a custom database
 uv run dqm --db /path/to/other.duckdb tables
 
+# Profile all columns in a table (nulls, cardinality, min/max, distribution)
+uv run dqm profile episodes
+uv run dqm --db /path/to/other.duckdb profile my_table
+
 # Generate a Markdown report for a table
 uv run dqm report episodes
 uv run dqm report episodes --output report.md
 ```
+
+## Column Profiler
+
+`dqm profile <table>` computes per-column statistics and renders them in a rich table:
+
+| Stat | Description |
+|------|-------------|
+| **Rows** | Total row count |
+| **Nulls** | Absolute null count |
+| **Null %** | Null percentage (highlighted red ≥ 20%, yellow ≥ 5%) |
+| **Unique** | Count of distinct non-null values |
+| **Min / Max** | Minimum and maximum value |
+| **Mean** | Average (numeric columns only) |
+| **P25 / P75** | 25th and 75th percentiles (numeric only) |
+| **Top values** | Top 5 most-frequent values with counts |
+
+Supported DuckDB types: `VARCHAR`, `INTEGER`, `BIGINT`, `FLOAT`, `DOUBLE`, `TIMESTAMP`, `JSON`, and more.
 
 ## Default data source
 

--- a/dqm/cli.py
+++ b/dqm/cli.py
@@ -78,5 +78,95 @@ def report(ctx: click.Context, table: str, output: str | None) -> None:
         click.echo(markdown, nl=False)
 
 
+@cli.command("profile")
+@click.argument("table")
+@click.pass_context
+def profile_cmd(ctx: click.Context, table: str) -> None:
+    """Profile every column in TABLE and pretty-print statistics."""
+    from rich.console import Console
+    from rich.table import Table as RichTable
+    from rich.text import Text
+    from .profiler import profile_table
+
+    db_path = ctx.obj["db"]
+    console = Console()
+
+    try:
+        prof = profile_table(db_path, table)
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+    except Exception as e:
+        console.print(f"[red]Error profiling table '{table}':[/red] {e}")
+        raise SystemExit(1)
+
+    # Header
+    console.print(
+        f"\n[bold cyan]Column profile[/bold cyan] — "
+        f"[bold]{prof.table}[/bold]  "
+        f"[dim]{db_path}[/dim]  "
+        f"[dim]{prof.profiled_at.strftime('%Y-%m-%d %H:%M UTC')}[/dim]\n"
+    )
+
+    rt = RichTable(show_header=True, header_style="bold magenta", show_lines=True)
+    rt.add_column("Column", style="cyan", no_wrap=True)
+    rt.add_column("Type", style="green")
+    rt.add_column("Rows", justify="right")
+    rt.add_column("Nulls", justify="right")
+    rt.add_column("Null %", justify="right")
+    rt.add_column("Unique", justify="right")
+    rt.add_column("Min", overflow="fold")
+    rt.add_column("Max", overflow="fold")
+    rt.add_column("Mean", justify="right")
+    rt.add_column("P25", justify="right")
+    rt.add_column("P75", justify="right")
+    rt.add_column("Top values (value: count)", overflow="fold")
+
+    for col in prof.columns:
+        # Colour null% red when it's significant
+        null_pct_str = f"{col.null_pct:.1%}"
+        null_text = Text(null_pct_str)
+        if col.null_pct >= 0.20:
+            null_text.stylize("bold red")
+        elif col.null_pct >= 0.05:
+            null_text.stylize("yellow")
+
+        top_str = "  ".join(f"{v}: {c:,}" for v, c in col.top_values) if col.top_values else "—"
+
+        rt.add_row(
+            col.name,
+            col.dtype,
+            f"{col.row_count:,}",
+            f"{col.null_count:,}",
+            null_text,
+            f"{col.unique_count:,}",
+            _fmt(col.min_val),
+            _fmt(col.max_val),
+            _fmt_float(col.mean),
+            _fmt_float(col.p25),
+            _fmt_float(col.p75),
+            top_str,
+        )
+
+    console.print(rt)
+    console.print(
+        f"\n[dim]{len(prof.columns)} column(s) profiled — "
+        f"{prof.columns[0].row_count:,} rows[/dim]\n" if prof.columns else ""
+    )
+
+
+def _fmt(val: object) -> str:
+    if val is None:
+        return "[dim]—[/dim]"
+    s = str(val)
+    return s[:40] + "…" if len(s) > 40 else s
+
+
+def _fmt_float(val: float | None) -> str:
+    if val is None:
+        return "[dim]—[/dim]"
+    return f"{val:,.2f}"
+
+
 def main() -> None:
     cli()

--- a/dqm/models.py
+++ b/dqm/models.py
@@ -1,18 +1,34 @@
 """Shared data models used across dqm modules."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 
 
 @dataclass
 class ColumnProfile:
     name: str
     dtype: str
+    row_count: int
+    null_count: int
     null_pct: float
     unique_count: int
-    min_value: object = None
-    max_value: object = None
-    top_values: list[str] = field(default_factory=list)
+    min_val: Any
+    max_val: Any
+    mean: float | None        # numeric only
+    p25: float | None         # numeric only
+    p75: float | None         # numeric only
+    top_values: list[tuple]   # top 5 most frequent (value, count) pairs
+
+
+@dataclass
+class TableProfile:
+    table: str
+    db_path: str
+    profiled_at: datetime
+    columns: list[ColumnProfile] = field(default_factory=list)
 
 
 @dataclass

--- a/dqm/profiler.py
+++ b/dqm/profiler.py
@@ -1,0 +1,229 @@
+"""Column profiler: nulls, cardinality, min/max, distribution for any DuckDB table."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import duckdb
+
+from .db import connect
+from .models import ColumnProfile, TableProfile
+
+# DuckDB type families that support numeric aggregates (mean, percentiles)
+_NUMERIC_TYPES = frozenset(
+    {
+        "TINYINT",
+        "SMALLINT",
+        "INTEGER",
+        "BIGINT",
+        "HUGEINT",
+        "UTINYINT",
+        "USMALLINT",
+        "UINTEGER",
+        "UBIGINT",
+        "FLOAT",
+        "DOUBLE",
+        "DECIMAL",
+        "REAL",
+    }
+)
+
+_TOP_N = 5
+
+
+def _is_numeric(dtype: str) -> bool:
+    """Return True if dtype belongs to the numeric family."""
+    return dtype.upper().split("(")[0].strip() in _NUMERIC_TYPES
+
+
+class Profiler:
+    """Produce a statistical profile of every column in a DuckDB table."""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def profile_table(self, conn: duckdb.DuckDBPyConnection, table_name: str) -> TableProfile:
+        """Profile every column in *table_name* and return a :class:`TableProfile`.
+
+        Parameters
+        ----------
+        conn:
+            An open DuckDB connection (read-only is fine).
+        table_name:
+            Name of the table to profile.
+
+        Returns
+        -------
+        TableProfile
+            Statistical profile with one :class:`ColumnProfile` per column.
+        """
+        # 1. Get column metadata from SUMMARIZE
+        summarize_rows = self._summarize(conn, table_name)
+
+        # 2. Get total row count once (cheaper than per-column)
+        row_count = self._row_count(conn, table_name)
+
+        columns: list[ColumnProfile] = []
+        for row in summarize_rows:
+            col_name, dtype = row["column_name"], row["column_type"]
+            null_count = self._null_count(conn, table_name, col_name, row_count)
+            null_pct = (null_count / row_count) if row_count > 0 else 0.0
+            unique_count = self._unique_count(conn, table_name, col_name)
+            min_val, max_val = self._min_max(conn, table_name, col_name)
+            mean, p25, p75 = self._numeric_stats(conn, table_name, col_name, dtype)
+            top_values = self._top_values(conn, table_name, col_name)
+
+            columns.append(
+                ColumnProfile(
+                    name=col_name,
+                    dtype=dtype,
+                    row_count=row_count,
+                    null_count=null_count,
+                    null_pct=null_pct,
+                    unique_count=unique_count,
+                    min_val=min_val,
+                    max_val=max_val,
+                    mean=mean,
+                    p25=p25,
+                    p75=p75,
+                    top_values=top_values,
+                )
+            )
+
+        return TableProfile(
+            table=table_name,
+            db_path="",  # filled in by the caller if desired
+            profiled_at=datetime.now(tz=timezone.utc),
+            columns=columns,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _summarize(
+        self, conn: duckdb.DuckDBPyConnection, table_name: str
+    ) -> list[dict[str, Any]]:
+        """Run DuckDB's SUMMARIZE and return rows as dicts."""
+        safe_name = _quote(table_name)
+        rows = conn.execute(f"SUMMARIZE {safe_name}").fetchall()
+        desc = conn.execute(f"SUMMARIZE {safe_name}").description
+        col_names = [d[0] for d in desc]
+        return [dict(zip(col_names, row)) for row in rows]
+
+    def _row_count(self, conn: duckdb.DuckDBPyConnection, table_name: str) -> int:
+        safe_name = _quote(table_name)
+        result = conn.execute(f"SELECT COUNT(*) FROM {safe_name}").fetchone()
+        return int(result[0]) if result else 0
+
+    def _null_count(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        table_name: str,
+        col_name: str,
+        row_count: int,
+    ) -> int:
+        safe_table = _quote(table_name)
+        safe_col = _quote(col_name)
+        result = conn.execute(
+            f"SELECT COUNT(*) FROM {safe_table} WHERE {safe_col} IS NULL"
+        ).fetchone()
+        return int(result[0]) if result else 0
+
+    def _unique_count(
+        self, conn: duckdb.DuckDBPyConnection, table_name: str, col_name: str
+    ) -> int:
+        safe_table = _quote(table_name)
+        safe_col = _quote(col_name)
+        result = conn.execute(
+            f"SELECT COUNT(DISTINCT {safe_col}) FROM {safe_table}"
+        ).fetchone()
+        return int(result[0]) if result else 0
+
+    def _min_max(
+        self, conn: duckdb.DuckDBPyConnection, table_name: str, col_name: str
+    ) -> tuple[Any, Any]:
+        safe_table = _quote(table_name)
+        safe_col = _quote(col_name)
+        result = conn.execute(
+            f"SELECT MIN({safe_col}), MAX({safe_col}) FROM {safe_table}"
+        ).fetchone()
+        if result:
+            return result[0], result[1]
+        return None, None
+
+    def _numeric_stats(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        table_name: str,
+        col_name: str,
+        dtype: str,
+    ) -> tuple[float | None, float | None, float | None]:
+        """Return (mean, p25, p75) for numeric columns; (None, None, None) otherwise."""
+        if not _is_numeric(dtype):
+            return None, None, None
+        safe_table = _quote(table_name)
+        safe_col = _quote(col_name)
+        try:
+            result = conn.execute(
+                f"""
+                SELECT
+                    AVG({safe_col}::DOUBLE),
+                    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY {safe_col}::DOUBLE),
+                    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY {safe_col}::DOUBLE)
+                FROM {safe_table}
+                """
+            ).fetchone()
+            if result:
+                mean = float(result[0]) if result[0] is not None else None
+                p25 = float(result[1]) if result[1] is not None else None
+                p75 = float(result[2]) if result[2] is not None else None
+                return mean, p25, p75
+        except Exception:
+            pass
+        return None, None, None
+
+    def _top_values(
+        self, conn: duckdb.DuckDBPyConnection, table_name: str, col_name: str
+    ) -> list[tuple]:
+        """Return the top-N most frequent (value, count) pairs, excluding NULLs."""
+        safe_table = _quote(table_name)
+        safe_col = _quote(col_name)
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT {safe_col}, COUNT(*) AS cnt
+                FROM {safe_table}
+                WHERE {safe_col} IS NOT NULL
+                GROUP BY {safe_col}
+                ORDER BY cnt DESC
+                LIMIT {_TOP_N}
+                """
+            ).fetchall()
+            return [(row[0], int(row[1])) for row in rows]
+        except Exception:
+            return []
+
+
+def _quote(name: str) -> str:
+    """Double-quote an identifier, escaping any embedded double-quotes."""
+    return '"' + name.replace('"', '""') + '"'
+
+
+# ---------------------------------------------------------------------------
+# Convenience function for the CLI
+# ---------------------------------------------------------------------------
+
+
+def profile_table(db_path: str, table_name: str) -> TableProfile:
+    """Open *db_path*, profile *table_name*, close connection, return profile."""
+    conn = connect(db_path)
+    try:
+        profiler = Profiler()
+        profile = profiler.profile_table(conn, table_name)
+        profile.db_path = db_path
+        return profile
+    finally:
+        conn.close()

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,262 @@
+"""Tests for dqm.profiler — uses real in-memory DuckDB connections."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import duckdb
+import pytest
+
+from dqm.models import ColumnProfile, TableProfile
+from dqm.profiler import Profiler, _quote
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn():
+    """In-memory DuckDB connection with a rich test table."""
+    con = duckdb.connect(":memory:")
+    con.execute(
+        """
+        CREATE TABLE episodes (
+            id        INTEGER,
+            title     VARCHAR,
+            score     DOUBLE,
+            published TIMESTAMP
+        )
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO episodes VALUES
+            (1,  'Ep One',   9.5,  '2026-01-01'),
+            (2,  'Ep Two',   8.0,  '2026-01-02'),
+            (3,  'Ep Three', 7.5,  '2026-01-03'),
+            (4,  'Ep Four',  NULL, '2026-01-04'),
+            (5,  NULL,       6.0,  NULL),
+            (6,  'Ep Four',  6.0,  '2026-01-06')
+        """
+    )
+    yield con
+    con.close()
+
+
+@pytest.fixture
+def profiler():
+    return Profiler()
+
+
+# ---------------------------------------------------------------------------
+# TableProfile shape
+# ---------------------------------------------------------------------------
+
+
+def test_profile_table_returns_table_profile(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    assert isinstance(result, TableProfile)
+    assert result.table == "episodes"
+    assert isinstance(result.profiled_at, datetime)
+
+
+def test_profile_table_has_correct_column_count(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    assert len(result.columns) == 4
+
+
+def test_profile_table_column_names(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    names = [c.name for c in result.columns]
+    assert "id" in names
+    assert "title" in names
+    assert "score" in names
+    assert "published" in names
+
+
+# ---------------------------------------------------------------------------
+# Row counts
+# ---------------------------------------------------------------------------
+
+
+def test_row_count_is_correct(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    for col in result.columns:
+        assert col.row_count == 6
+
+
+# ---------------------------------------------------------------------------
+# Null stats
+# ---------------------------------------------------------------------------
+
+
+def test_null_count_varchar(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    assert title.null_count == 1
+
+
+def test_null_pct_varchar(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    assert pytest.approx(title.null_pct, rel=1e-3) == 1 / 6
+
+
+def test_null_count_numeric(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    score = next(c for c in result.columns if c.name == "score")
+    assert score.null_count == 1
+
+
+def test_null_pct_no_nulls(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    id_col = next(c for c in result.columns if c.name == "id")
+    assert id_col.null_count == 0
+    assert id_col.null_pct == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cardinality
+# ---------------------------------------------------------------------------
+
+
+def test_unique_count_id(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    id_col = next(c for c in result.columns if c.name == "id")
+    assert id_col.unique_count == 6
+
+
+def test_unique_count_title_with_duplicate(profiler, conn):
+    # 'Ep Four' appears twice; title has 1 NULL → 4 distinct non-null values
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    # DISTINCT includes nulls in DuckDB COUNT(DISTINCT): nulls are excluded
+    assert title.unique_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Min / Max
+# ---------------------------------------------------------------------------
+
+
+def test_min_max_integer(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    id_col = next(c for c in result.columns if c.name == "id")
+    assert id_col.min_val == 1
+    assert id_col.max_val == 6
+
+
+def test_min_max_double(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    score = next(c for c in result.columns if c.name == "score")
+    assert score.min_val == pytest.approx(6.0)
+    assert score.max_val == pytest.approx(9.5)
+
+
+def test_min_max_varchar(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    assert title.min_val is not None
+    assert title.max_val is not None
+
+
+# ---------------------------------------------------------------------------
+# Numeric stats (mean, p25, p75)
+# ---------------------------------------------------------------------------
+
+
+def test_mean_numeric(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    score = next(c for c in result.columns if c.name == "score")
+    # Values: 9.5, 8.0, 7.5, NULL, 6.0, 6.0 → mean of non-null = 37.0/5 = 7.4
+    assert score.mean == pytest.approx(7.4, rel=1e-3)
+
+
+def test_p25_p75_numeric(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    score = next(c for c in result.columns if c.name == "score")
+    assert score.p25 is not None
+    assert score.p75 is not None
+    assert score.p25 <= score.p75
+
+
+def test_no_numeric_stats_for_varchar(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    assert title.mean is None
+    assert title.p25 is None
+    assert title.p75 is None
+
+
+def test_no_numeric_stats_for_timestamp(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    published = next(c for c in result.columns if c.name == "published")
+    assert published.mean is None
+
+
+# ---------------------------------------------------------------------------
+# Top values
+# ---------------------------------------------------------------------------
+
+
+def test_top_values_is_list_of_tuples(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    assert isinstance(title.top_values, list)
+    for item in title.top_values:
+        assert isinstance(item, tuple)
+        assert len(item) == 2
+
+
+def test_top_values_most_frequent_first(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    # 'Ep Four' appears twice, should be first
+    assert title.top_values[0][0] == "Ep Four"
+    assert title.top_values[0][1] == 2
+
+
+def test_top_values_excludes_nulls(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    title = next(c for c in result.columns if c.name == "title")
+    values = [v for v, _ in title.top_values]
+    assert None not in values
+
+
+def test_top_values_at_most_five(profiler, conn):
+    result = profiler.profile_table(conn, "episodes")
+    for col in result.columns:
+        assert len(col.top_values) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Empty table edge case
+# ---------------------------------------------------------------------------
+
+
+def test_empty_table(profiler):
+    con = duckdb.connect(":memory:")
+    con.execute("CREATE TABLE empty_t (x INTEGER, y VARCHAR)")
+    result = profiler.profile_table(con, "empty_t")
+    assert result.table == "empty_t"
+    assert len(result.columns) == 2
+    for col in result.columns:
+        assert col.row_count == 0
+        assert col.null_count == 0
+        assert col.null_pct == 0.0
+    con.close()
+
+
+# ---------------------------------------------------------------------------
+# _quote helper
+# ---------------------------------------------------------------------------
+
+
+def test_quote_simple():
+    assert _quote("my_table") == '"my_table"'
+
+
+def test_quote_with_embedded_double_quote():
+    assert _quote('my"table') == '"my""table"'


### PR DESCRIPTION
## Summary

Implements issue #5: a statistical column profiler for any DuckDB table.

## Changes

### `dqm/profiler.py` (new)
- `Profiler.profile_table(conn, table_name) -> TableProfile` — uses DuckDB's `SUMMARIZE` as the base and enriches with targeted queries:
  - **Null stats**: `null_count`, `null_pct` via `COUNT(*) WHERE col IS NULL`
  - **Cardinality**: `unique_count` via `COUNT(DISTINCT col)`
  - **Min / Max**: single `MIN` / `MAX` query per column
  - **Numeric stats**: `mean`, `p25`, `p75` via `AVG` + `PERCENTILE_CONT` (numeric types only)
  - **Top values**: top-5 most frequent `(value, count)` pairs, NULLs excluded
- Handles all DuckDB types: `VARCHAR`, `INTEGER`, `BIGINT`, `FLOAT`, `DOUBLE`, `TIMESTAMP`, `JSON`, etc.
- `profile_table(db_path, table_name)` convenience function used by the CLI

### `dqm/models.py` (updated)
- `ColumnProfile` updated to match the issue spec: adds `row_count`, `null_count`, `mean`, `p25`, `p75`; `top_values` is now `list[tuple]`
- New `TableProfile` dataclass grouping the per-column profiles with table name, db path, and timestamp

### `dqm/cli.py` (updated)
- New `dqm profile <table>` command
- Renders a rich table with colour-coded null% (red ≥ 20%, yellow ≥ 5%)
- Numeric-only columns show mean/p25/p75; non-numeric shows em-dash

### `tests/test_profiler.py` (new)
- 24 tests covering: table shape, row counts, null stats, cardinality, min/max, numeric aggregates, top values, empty-table edge case, and the `_quote` helper

### `README.md` (updated)
- Documents `dqm profile` command and a stat reference table

## Acceptance criteria

✅ `Profiler.profile_table()` implemented  
✅ DuckDB `SUMMARIZE` used as base, enriched with additional queries  
✅ Handles VARCHAR, INTEGER, FLOAT, DOUBLE, TIMESTAMP (JSON treated as VARCHAR)  
✅ `dqm profile <table>` CLI with rich pretty-printing  
✅ All 51 tests pass (24 new + 27 existing)

Closes #5