### PR TITLE
feat: anomaly detector — threshold rules + dqm check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ uv run dqm --db /path/to/other.duckdb tables
 uv run dqm profile episodes
 uv run dqm --db /path/to/other.duckdb profile my_table
 
+# Run full anomaly check: profile → snapshot → diff → flag rule violations
+uv run dqm check episodes
+uv run dqm --db /path/to/other.duckdb check my_table
+
 # Generate a Markdown report for a table
 uv run dqm report episodes
 uv run dqm report episodes --output report.md
@@ -51,6 +55,42 @@ The tool defaults to the P³ (parakeet-podcast-processor) DuckDB, checking these
 2. `~/Code/parakeet-podcast-processor/data/p3.duckdb`
 
 Override with `--db <path>`.
+
+## Anomaly Detector
+
+`dqm check <table>` profiles the table, saves a snapshot, diffs it against the
+previous snapshot, and runs all threshold rules.  Each anomaly shows the
+triggering rule, the old and new values, and a severity badge.
+
+### Default rules
+
+| Rule | Condition | Severity |
+|------|-----------|----------|
+| `null_pct_increase` | null % rose by > 10 pp | **ALERT** |
+| `unique_count_drop` | unique count fell by > 20 % | **WARN** |
+| `row_count_decrease` | row count decreased at all | **ALERT** |
+| `row_count_spike` | row count increased by > 500 % | **WARN** |
+| `max_val_decrease` | max value fell for a monotonic column | **ALERT** |
+
+### Configuration
+
+Thresholds are read from `~/.dqm/anomaly_config.yaml` (user overrides) falling
+back to the bundled `dqm/anomaly_config.yaml`.  Example override:
+
+```yaml
+thresholds:
+  null_pct_increase_pp: 5.0        # fire at 5 pp instead of 10 pp
+  unique_count_drop_pct: 0.10      # fire at 10 % drop instead of 20 %
+  row_count_increase_pct: 2.00     # fire at 200 % increase instead of 500 %
+  monotonic_columns:               # check max_val for these columns
+    - episode_id
+    - published_at
+```
+
+Pass a custom config path with `--anomaly-config <path>`.
+
+Snapshots are stored in `~/.dqm/snapshots.db` (SQLite).  Override with
+`--snapshots-db <path>`.
 
 ## P³ columns worth monitoring
 

--- a/dqm/anomaly.py
+++ b/dqm/anomaly.py
@@ -1,0 +1,285 @@
+"""Rule-based anomaly detector.
+
+Compares two :class:`~dqm.models.TableProfile` snapshots using a set of
+configurable threshold rules and returns a list of :class:`~dqm.models.Anomaly`
+objects.
+
+Default rules
+-------------
+1. **null_pct_increase** — null % rose by > 10 pp                  → ALERT
+2. **unique_count_drop** — unique count fell by > 20 %              → WARN
+3. **row_count_decrease** — row count decreased at all              → ALERT
+4. **row_count_spike**   — row count increased by > 500 %           → WARN
+5. **max_val_decrease**  — max_val fell for a monotonic column      → ALERT
+
+Configuration
+-------------
+Thresholds can be customised via a YAML file.  The detector looks for
+``~/.dqm/anomaly_config.yaml`` first; if that is absent it falls back to the
+built-in ``anomaly_config.yaml`` bundled with the package.  You can also pass
+``config_path`` explicitly.
+
+Usage
+-----
+>>> from dqm.anomaly import AnomalyDetector
+>>> detector = AnomalyDetector()
+>>> anomalies = detector.detect(profile_before, profile_after)
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+from .models import Anomaly, ColumnProfile, TableProfile
+
+# ---------------------------------------------------------------------------
+# YAML loading (stdlib only — no extra dep required)
+# ---------------------------------------------------------------------------
+
+try:
+    import yaml as _yaml
+
+    def _load_yaml(path: Path) -> dict[str, Any]:
+        with path.open() as fh:
+            return _yaml.safe_load(fh) or {}
+
+except ImportError:
+    # PyYAML not installed — fall back to a minimal hand-rolled parser that
+    # covers only the simple key: value pairs used by our config.
+    import re as _re
+
+    def _load_yaml(path: Path) -> dict[str, Any]:  # type: ignore[misc]
+        """Very minimal YAML subset parser (no PyYAML dependency)."""
+        result: dict[str, Any] = {"thresholds": {}, "severity": {}}
+        section: dict[str, Any] = {}
+
+        with path.open() as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+
+                # Top-level section header (no leading spaces, ends with colon)
+                if not line.startswith(" ") and stripped.endswith(":"):
+                    key = stripped[:-1]
+                    section = {}
+                    result[key] = section
+                    continue
+
+                # Key: value pair (with optional inline comment)
+                m = _re.match(r"\s+([\w_]+):\s*(.+)", line)
+                if m:
+                    k, v = m.group(1), m.group(2).split("#")[0].strip()
+                    if v in ("true", "True"):
+                        section[k] = True
+                    elif v in ("false", "False"):
+                        section[k] = False
+                    elif v.startswith("[") and v.endswith("]"):
+                        section[k] = []
+                    else:
+                        try:
+                            section[k] = float(v)
+                        except ValueError:
+                            section[k] = v
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Default config path (bundled alongside this file)
+# ---------------------------------------------------------------------------
+
+_BUNDLED_CONFIG = Path(__file__).parent / "anomaly_config.yaml"
+_USER_CONFIG = Path.home() / ".dqm" / "anomaly_config.yaml"
+
+
+def _load_config(config_path: Path | None) -> dict[str, Any]:
+    """Load thresholds from YAML, merging user overrides over bundled defaults."""
+    # 1. Start with bundled defaults
+    cfg: dict[str, Any] = {}
+    if _BUNDLED_CONFIG.exists():
+        cfg = _load_yaml(_BUNDLED_CONFIG)
+
+    # 2. Overlay user config if present
+    user = config_path or _USER_CONFIG
+    if user.exists():
+        user_cfg = _load_yaml(user)
+        for section_key, section_val in user_cfg.items():
+            if isinstance(section_val, dict):
+                cfg.setdefault(section_key, {}).update(section_val)
+            else:
+                cfg[section_key] = section_val
+
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# AnomalyDetector
+# ---------------------------------------------------------------------------
+
+class AnomalyDetector:
+    """Detect data quality anomalies using configurable threshold rules.
+
+    Parameters
+    ----------
+    config_path:
+        Path to a YAML config file.  Defaults to ``~/.dqm/anomaly_config.yaml``
+        (falls back to the bundled defaults if the file does not exist).
+    """
+
+    def __init__(self, config_path: Path | str | None = None) -> None:
+        cp = Path(config_path) if config_path else None
+        cfg = _load_config(cp)
+        t = cfg.get("thresholds", {})
+        s = cfg.get("severity", {})
+
+        self._null_pct_increase_pp: float = float(t.get("null_pct_increase_pp", 10.0))
+        self._unique_count_drop_pct: float = float(t.get("unique_count_drop_pct", 0.20))
+        self._row_count_decrease: bool = bool(t.get("row_count_decrease", True))
+        self._row_count_increase_pct: float = float(t.get("row_count_increase_pct", 5.00))
+        self._monotonic_columns: list[str] = list(t.get("monotonic_columns") or [])
+
+        self._label_alert: str = str(s.get("alert", "ALERT"))
+        self._label_warn: str = str(s.get("warn", "WARN"))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def detect(
+        self,
+        before: TableProfile,
+        after: TableProfile,
+    ) -> list[Anomaly]:
+        """Run all rules and return every triggered anomaly.
+
+        Parameters
+        ----------
+        before:
+            The older / baseline snapshot.
+        after:
+            The newer / current snapshot.
+
+        Returns
+        -------
+        list[Anomaly]
+            One entry per triggered rule per column (or table-level metric).
+        """
+        anomalies: list[Anomaly] = []
+
+        cols_before = {c.name: c for c in before.columns}
+        cols_after = {c.name: c for c in after.columns}
+
+        # --- Table-level row count rules (use row_count from first column) ---
+        rc_before = before.columns[0].row_count if before.columns else 0
+        rc_after = after.columns[0].row_count if after.columns else 0
+        anomalies.extend(self._check_row_count(rc_before, rc_after))
+
+        # --- Column-level rules ---
+        for col_name, col_after in cols_after.items():
+            col_before = cols_before.get(col_name)
+            if col_before is None:
+                continue  # new column — skip for now
+
+            anomalies.extend(self._check_null_pct(col_before, col_after))
+            anomalies.extend(self._check_unique_count(col_before, col_after))
+
+            if col_name in self._monotonic_columns:
+                anomalies.extend(self._check_max_val_decrease(col_before, col_after))
+
+        return anomalies
+
+    # ------------------------------------------------------------------
+    # Individual rule checks
+    # ------------------------------------------------------------------
+
+    def _check_null_pct(
+        self, before: ColumnProfile, after: ColumnProfile
+    ) -> list[Anomaly]:
+        """Rule 1: null_pct increased by > threshold pp → ALERT."""
+        delta_pp = (after.null_pct - before.null_pct) * 100.0
+        if delta_pp > self._null_pct_increase_pp:
+            return [
+                Anomaly(
+                    column=after.name,
+                    rule_triggered="null_pct_increase",
+                    old_val=before.null_pct * 100.0,
+                    new_val=after.null_pct * 100.0,
+                    severity=self._label_alert,
+                )
+            ]
+        return []
+
+    def _check_unique_count(
+        self, before: ColumnProfile, after: ColumnProfile
+    ) -> list[Anomaly]:
+        """Rule 2: unique_count dropped by > threshold % → WARN."""
+        if before.unique_count == 0:
+            return []
+        drop_pct = (before.unique_count - after.unique_count) / before.unique_count
+        if drop_pct > self._unique_count_drop_pct:
+            return [
+                Anomaly(
+                    column=after.name,
+                    rule_triggered="unique_count_drop",
+                    old_val=float(before.unique_count),
+                    new_val=float(after.unique_count),
+                    severity=self._label_warn,
+                )
+            ]
+        return []
+
+    def _check_row_count(self, rc_before: int, rc_after: int) -> list[Anomaly]:
+        """Rules 3 & 4: row count decreased → ALERT; increased > threshold → WARN."""
+        results: list[Anomaly] = []
+
+        if self._row_count_decrease and rc_after < rc_before:
+            results.append(
+                Anomaly(
+                    column="__table__",
+                    rule_triggered="row_count_decrease",
+                    old_val=float(rc_before),
+                    new_val=float(rc_after),
+                    severity=self._label_alert,
+                )
+            )
+
+        if rc_before > 0:
+            increase_factor = rc_after / rc_before
+            if increase_factor > 1 + self._row_count_increase_pct:
+                results.append(
+                    Anomaly(
+                        column="__table__",
+                        rule_triggered="row_count_spike",
+                        old_val=float(rc_before),
+                        new_val=float(rc_after),
+                        severity=self._label_warn,
+                    )
+                )
+
+        return results
+
+    def _check_max_val_decrease(
+        self, before: ColumnProfile, after: ColumnProfile
+    ) -> list[Anomaly]:
+        """Rule 5: max_val decreased for a monotonically increasing column → ALERT."""
+        try:
+            max_before = float(before.max_val)  # type: ignore[arg-type]
+            max_after = float(after.max_val)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return []  # non-numeric / None — skip
+
+        if not math.isnan(max_before) and not math.isnan(max_after):
+            if max_after < max_before:
+                return [
+                    Anomaly(
+                        column=after.name,
+                        rule_triggered="max_val_decrease",
+                        old_val=max_before,
+                        new_val=max_after,
+                        severity=self._label_alert,
+                    )
+                ]
+        return []

--- a/dqm/anomaly_config.yaml
+++ b/dqm/anomaly_config.yaml
@@ -1,0 +1,25 @@
+# Anomaly detector threshold configuration
+# All values can be overridden by placing a custom copy at ~/.dqm/anomaly_config.yaml
+# or by passing a config_path to AnomalyDetector.
+
+thresholds:
+  # Rule: null_pct increased by more than this many percentage-points → ALERT
+  null_pct_increase_pp: 10.0   # 10 pp
+
+  # Rule: unique_count dropped by more than this fraction → WARN
+  unique_count_drop_pct: 0.20  # 20 %
+
+  # Rule: row_count decreased at all → ALERT  (threshold: any decrease)
+  row_count_decrease: true
+
+  # Rule: row_count increased by more than this multiple → WARN  (500 % = 5× original)
+  row_count_increase_pct: 5.00  # 500 %
+
+  # Rule: max_val decreased for a column marked monotonically increasing → ALERT
+  # List the column names that are expected to be monotonically increasing.
+  monotonic_columns: []
+
+# Severity labels (do not change unless you know what you are doing)
+severity:
+  alert: "ALERT"
+  warn: "WARN"

--- a/dqm/cli.py
+++ b/dqm/cli.py
@@ -51,10 +51,10 @@ def tables_cmd(ctx: click.Context) -> None:
 def report(ctx: click.Context, table: str, output: str | None) -> None:
     """Generate a Markdown data quality report for TABLE."""
     from datetime import datetime, timezone
-    from .models import ColumnDiff, TableDiff
+    from .models import TableDiff
     from .report import ReportGenerator
 
-    # Placeholder diff — real data comes from snapshot store (#6) and diff engine (#7)
+    # Placeholder diff — real data comes from snapshot store and diff engine
     now = datetime.now(tz=timezone.utc)
     diff = TableDiff(
         table=table,
@@ -153,6 +153,253 @@ def profile_cmd(ctx: click.Context, table: str) -> None:
         f"\n[dim]{len(prof.columns)} column(s) profiled — "
         f"{prof.columns[0].row_count:,} rows[/dim]\n" if prof.columns else ""
     )
+
+
+@cli.command("check")
+@click.argument("table")
+@click.option(
+    "--snapshots-db",
+    default=None,
+    help="Path to snapshot SQLite DB. Defaults to ~/.dqm/snapshots.db.",
+)
+@click.option(
+    "--anomaly-config",
+    default=None,
+    help="Path to anomaly detector YAML config. Defaults to ~/.dqm/anomaly_config.yaml.",
+)
+@click.option(
+    "--save/--no-save",
+    default=True,
+    show_default=True,
+    help="Save the new profile snapshot after checking.",
+)
+@click.pass_context
+def check_cmd(
+    ctx: click.Context,
+    table: str,
+    snapshots_db: str | None,
+    anomaly_config: str | None,
+    save: bool,
+) -> None:
+    """Profile TABLE, diff against last snapshot, and flag anomalies.
+
+    On first run (no prior snapshot) the profile is saved and you are told to
+    run again after a data change.  On subsequent runs the current profile is
+    compared against the previous one and any rule violations are printed.
+    """
+    from pathlib import Path as _Path
+
+    from rich.console import Console
+    from rich.table import Table as RichTable
+    from rich.text import Text
+
+    from .anomaly import AnomalyDetector
+    from .diff import DiffEngine
+    from .models import Anomaly
+    from .profiler import profile_table
+    from .snapshots import (
+        _DEFAULT_DB as _SNAP_DEFAULT,
+        get_latest_two_snapshots,
+        save_snapshot,
+    )
+
+    db_path = ctx.obj["db"]
+    snap_db = _Path(snapshots_db) if snapshots_db else _SNAP_DEFAULT
+    cfg_path = _Path(anomaly_config) if anomaly_config else None
+    console = Console()
+
+    # ------------------------------------------------------------------ #
+    # 1. Profile current state
+    # ------------------------------------------------------------------ #
+    console.print(f"\n[bold cyan]dqm check[/bold cyan] — [bold]{table}[/bold]  [dim]{db_path}[/dim]\n")
+    console.print("[dim]Step 1/3  Profiling table…[/dim]")
+
+    try:
+        current = profile_table(db_path, table)
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+    except Exception as e:
+        console.print(f"[red]Error profiling '{table}':[/red] {e}")
+        raise SystemExit(1)
+
+    row_count = current.columns[0].row_count if current.columns else 0
+    console.print(
+        f"  Profiled [bold]{len(current.columns)}[/bold] columns, "
+        f"[bold]{row_count:,}[/bold] rows.\n"
+    )
+
+    # ------------------------------------------------------------------ #
+    # 2. Save snapshot (optionally)
+    # ------------------------------------------------------------------ #
+    if save:
+        snap_id = save_snapshot(current, snap_db)
+        console.print(f"[dim]  Snapshot saved → id={snap_id} ({snap_db})[/dim]\n")
+
+    # ------------------------------------------------------------------ #
+    # 3. Retrieve previous snapshot for diffing
+    # ------------------------------------------------------------------ #
+    console.print("[dim]Step 2/3  Loading previous snapshot…[/dim]")
+    pair = get_latest_two_snapshots(table, snap_db)
+
+    if pair is None:
+        console.print(
+            "  [yellow]No prior snapshot found — this is the baseline.[/yellow]\n"
+            "  Run [bold]dqm check[/bold] again after your next data load to detect anomalies.\n"
+        )
+        raise SystemExit(0)
+
+    before, after = pair
+    console.print(
+        f"  Comparing snapshot from [bold]{before.profiled_at.strftime('%Y-%m-%d %H:%M UTC')}[/bold] "
+        f"→ [bold]{after.profiled_at.strftime('%Y-%m-%d %H:%M UTC')}[/bold]\n"
+    )
+
+    # ------------------------------------------------------------------ #
+    # 4. Diff + anomaly detection
+    # ------------------------------------------------------------------ #
+    console.print("[dim]Step 3/3  Running anomaly detection…[/dim]\n")
+    diff = DiffEngine().diff(before, after)
+    detector = AnomalyDetector(config_path=cfg_path)
+    anomalies = detector.detect(before, after)
+
+    # ------------------------------------------------------------------ #
+    # 5. Print results
+    # ------------------------------------------------------------------ #
+    _print_diff_table(console, diff)
+    _print_anomalies(console, anomalies)
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _print_diff_table(console: object, diff: object) -> None:  # type: ignore[type-arg]
+    """Print a Rich table showing per-column diffs."""
+    from rich.console import Console
+    from rich.table import Table as RichTable
+    from rich.text import Text
+    from .models import TableDiff
+
+    console = console  # type: Console  # noqa: F841
+    diff = diff  # type: TableDiff  # noqa: F841
+
+    rt = RichTable(
+        title="Column Diff",
+        show_header=True,
+        header_style="bold magenta",
+        show_lines=True,
+    )
+    rt.add_column("Column", style="cyan", no_wrap=True)
+    rt.add_column("Type", style="green")
+    rt.add_column("Rows (before→after)", justify="right")
+    rt.add_column("Null % (before→after)", justify="right")
+    rt.add_column("Null Δ", justify="right")
+    rt.add_column("Unique (before→after)", justify="right")
+
+    for col in diff.columns:
+        delta = col.null_pct_delta * 100
+        sign = "+" if delta >= 0 else ""
+        delta_text = Text(f"{sign}{delta:.1f}pp")
+        if delta > 10:
+            delta_text.stylize("bold red")
+        elif delta > 2:
+            delta_text.stylize("yellow")
+
+        rc_before = getattr(col, "row_count_before", 0)
+        rc_after = getattr(col, "row_count_after", 0)
+
+        rt.add_row(
+            col.column,
+            col.dtype,
+            f"{rc_before:,} → {rc_after:,}",
+            f"{col.null_pct_before:.1%} → {col.null_pct_after:.1%}",
+            delta_text,
+            f"{col.unique_before:,} → {col.unique_after:,}",
+        )
+
+    console.print(rt)
+    console.print()
+
+
+def _print_anomalies(console: object, anomalies: list) -> None:  # type: ignore[type-arg]
+    """Print a summary of detected anomalies."""
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table as RichTable
+    from rich.text import Text
+
+    console = console  # type: Console  # noqa: F841
+
+    if not anomalies:
+        console.print(Panel("[bold green]✓ No anomalies detected[/bold green]", expand=False))
+        console.print()
+        return
+
+    n_alert = sum(1 for a in anomalies if a.severity == "ALERT")
+    n_warn = sum(1 for a in anomalies if a.severity == "WARN")
+
+    title_color = "red" if n_alert else "yellow"
+    title = f"[bold {title_color}]{len(anomalies)} anomal{'y' if len(anomalies) == 1 else 'ies'} detected"
+    if n_alert:
+        title += f" — {n_alert} ALERT"
+    if n_warn:
+        title += f" — {n_warn} WARN"
+    title += "[/bold " + title_color + "]"
+
+    rt = RichTable(
+        title=title,
+        show_header=True,
+        header_style="bold white",
+        show_lines=True,
+    )
+    rt.add_column("Severity", justify="center", no_wrap=True)
+    rt.add_column("Column", style="cyan", no_wrap=True)
+    rt.add_column("Rule", style="magenta")
+    rt.add_column("Old value", justify="right")
+    rt.add_column("New value", justify="right")
+    rt.add_column("Change", justify="right")
+
+    for anomaly in anomalies:
+        sev_text = Text(anomaly.severity)
+        if anomaly.severity == "ALERT":
+            sev_text.stylize("bold red")
+        else:
+            sev_text.stylize("bold yellow")
+
+        old_v = anomaly.old_val
+        new_v = anomaly.new_val
+
+        # Format based on rule type
+        rule = anomaly.rule_triggered
+        if rule == "null_pct_increase":
+            old_s = f"{old_v:.1f}%"
+            new_s = f"{new_v:.1f}%"
+            change = f"+{new_v - old_v:.1f}pp"
+        elif rule in ("row_count_decrease", "row_count_spike"):
+            old_s = f"{old_v:,.0f}"
+            new_s = f"{new_v:,.0f}"
+            pct = ((new_v - old_v) / old_v * 100) if old_v else 0
+            sign = "+" if pct >= 0 else ""
+            change = f"{sign}{pct:.0f}%"
+        elif rule == "unique_count_drop":
+            old_s = f"{old_v:,.0f}"
+            new_s = f"{new_v:,.0f}"
+            pct = ((new_v - old_v) / old_v * 100) if old_v else 0
+            change = f"{pct:.0f}%"
+        elif rule == "max_val_decrease":
+            old_s = f"{old_v:g}"
+            new_s = f"{new_v:g}"
+            change = f"{new_v - old_v:+g}"
+        else:
+            old_s = str(old_v)
+            new_s = str(new_v)
+            change = "—"
+
+        rt.add_row(sev_text, anomaly.column, rule, old_s, new_s, change)
+
+    console.print(rt)
+    console.print()
 
 
 def _fmt(val: object) -> str:

--- a/dqm/diff.py
+++ b/dqm/diff.py
@@ -1,0 +1,77 @@
+"""Diff engine: compare two TableProfile snapshots and surface what changed."""
+
+from __future__ import annotations
+
+from .models import ColumnDiff, ColumnProfile, TableDiff, TableProfile
+
+
+class DiffEngine:
+    """Compare two :class:`~dqm.models.TableProfile` snapshots.
+
+    Parameters
+    ----------
+    alert_pp:
+        Null-% change threshold for **alert** severity (default 10 pp).
+    warn_pp:
+        Null-% change threshold for **warn** severity (default 2 pp).
+    """
+
+    def __init__(self, alert_pp: float = 0.10, warn_pp: float = 0.02) -> None:
+        self._alert_pp = alert_pp
+        self._warn_pp = warn_pp
+
+    def diff(self, snapshot_a: TableProfile, snapshot_b: TableProfile) -> TableDiff:
+        """Compare *snapshot_a* (before) against *snapshot_b* (after).
+
+        Columns that exist in both snapshots are compared field-by-field.
+        Columns present in only one snapshot are silently skipped.
+        """
+        cols_a: dict[str, ColumnProfile] = {c.name: c for c in snapshot_a.columns}
+        cols_b: dict[str, ColumnProfile] = {c.name: c for c in snapshot_b.columns}
+
+        shared_names = [n for n in cols_b if n in cols_a]
+
+        column_diffs: list[ColumnDiff] = []
+        for name in shared_names:
+            col_diff = self._diff_column(cols_a[name], cols_b[name])
+            column_diffs.append(col_diff)
+
+        return TableDiff(
+            table=snapshot_b.table,
+            snapshot_before=snapshot_a.profiled_at.isoformat(),
+            snapshot_after=snapshot_b.profiled_at.isoformat(),
+            date_before=snapshot_a.profiled_at,
+            date_after=snapshot_b.profiled_at,
+            columns=column_diffs,
+        )
+
+    def _diff_column(self, before: ColumnProfile, after: ColumnProfile) -> ColumnDiff:
+        """Build a :class:`ColumnDiff` for a single column."""
+        null_pct_delta = after.null_pct - before.null_pct
+        sev = self._assess_severity(null_pct_delta)
+
+        return ColumnDiff(
+            column=before.name,
+            dtype=after.dtype,
+            null_pct_before=before.null_pct,
+            null_pct_after=after.null_pct,
+            unique_before=before.unique_count,
+            unique_after=after.unique_count,
+            min_before=before.min_val,
+            min_after=after.min_val,
+            max_before=before.max_val,
+            max_after=after.max_val,
+            row_count_before=before.row_count,
+            row_count_after=after.row_count,
+            top_values_before=list(before.top_values),
+            top_values_after=list(after.top_values),
+            severity=sev,
+        )
+
+    def _assess_severity(self, null_pct_delta: float) -> str:
+        _EPS = 1e-9
+        if null_pct_delta >= self._alert_pp - _EPS:
+            return "alert"
+        if null_pct_delta >= self._warn_pp - _EPS:
+            return "warn"
+        return "ok"

--- a/dqm/models.py
+++ b/dqm/models.py
@@ -41,30 +41,136 @@ class AnomalyContext:
 
 @dataclass
 class ColumnDiff:
+    """Per-column diff between two TableProfile snapshots."""
+
     column: str
     dtype: str
+
+    # Null stats
     null_pct_before: float
     null_pct_after: float
+
+    # Cardinality
     unique_before: int
     unique_after: int
 
+    # Range drift (kept as raw values — could be numeric, date, str …)
+    min_before: Any = None
+    min_after: Any = None
+    max_before: Any = None
+    max_after: Any = None
+
+    # Row counts
+    row_count_before: int = 0
+    row_count_after: int = 0
+
+    # Top values
+    top_values_before: list[tuple] = field(default_factory=list)
+    top_values_after: list[tuple] = field(default_factory=list)
+
+    # Severity from diff engine
+    severity: str = "ok"   # "ok" | "warn" | "alert"
+
     @property
     def null_pct_delta(self) -> float:
+        """Change in null % (percentage-points)."""
         return self.null_pct_after - self.null_pct_before
 
+    @property
+    def unique_delta(self) -> int:
+        """Change in unique count (absolute)."""
+        return self.unique_after - self.unique_before
 
-@dataclass
+    @property
+    def new_top_values(self) -> list[Any]:
+        """Values that appear in top_values_after but not in top_values_before."""
+        before_vals = {v for v, _ in self.top_values_before}
+        return [v for v, _ in self.top_values_after if v not in before_vals]
+
+
 class Anomaly:
-    column: str
-    metric: str
-    value_before: float
-    value_after: float
-    severity: str  # "ALERT" | "WARNING" | "OK"
-    delta_pp: float = 0.0
+    """A single anomaly detected by the rule-based AnomalyDetector.
+
+    Supports two calling conventions:
+
+    **New** (issue #8):
+        ``Anomaly(column=..., rule_triggered=..., old_val=..., new_val=..., severity=...)``
+
+    **Legacy** (issues #2/#3):
+        ``Anomaly(column=..., metric=..., value_before=..., value_after=..., severity=..., delta_pp=...)``
+
+    Both sets of names are available as attributes after construction.
+    """
+
+    def __init__(
+        self,
+        column: str,
+        severity: str,
+        # New-style fields
+        rule_triggered: str | None = None,
+        old_val: float | None = None,
+        new_val: float | None = None,
+        # Legacy fields (kept for backward compatibility)
+        metric: str | None = None,
+        value_before: float | None = None,
+        value_after: float | None = None,
+        delta_pp: float | None = None,
+    ) -> None:
+        self.column = column
+        self.severity = severity
+
+        # Unify: new-style takes precedence; fall back to legacy names
+        self.rule_triggered: str = rule_triggered or metric or ""
+        self.old_val: float = old_val if old_val is not None else (value_before if value_before is not None else 0.0)
+        self.new_val: float = new_val if new_val is not None else (value_after if value_after is not None else 0.0)
+
+        # Explicit delta_pp can override computed value (legacy callers may pass it)
+        if delta_pp is not None:
+            self._delta_pp: float | None = delta_pp
+        else:
+            self._delta_pp = None
+
+    # --- Aliases ---
+    @property
+    def metric(self) -> str:
+        return self.rule_triggered
+
+    @property
+    def value_before(self) -> float:
+        return self.old_val
+
+    @property
+    def value_after(self) -> float:
+        return self.new_val
+
+    @property
+    def delta_pp(self) -> float:
+        if self._delta_pp is not None:
+            return self._delta_pp
+        return self.new_val - self.old_val
+
+    def __repr__(self) -> str:
+        return (
+            f"Anomaly(column={self.column!r}, rule_triggered={self.rule_triggered!r}, "
+            f"old_val={self.old_val}, new_val={self.new_val}, severity={self.severity!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Anomaly):
+            return NotImplemented
+        return (
+            self.column == other.column
+            and self.rule_triggered == other.rule_triggered
+            and self.old_val == other.old_val
+            and self.new_val == other.new_val
+            and self.severity == other.severity
+        )
 
 
 @dataclass
 class TableDiff:
+    """Result of comparing two TableProfile snapshots for the same table."""
+
     table: str
     snapshot_before: str
     snapshot_after: str

--- a/dqm/snapshots.py
+++ b/dqm/snapshots.py
@@ -1,0 +1,207 @@
+"""Snapshot store: persist TableProfile snapshots in a local SQLite database.
+
+The database lives at ``~/.dqm/snapshots.db`` and grows every time a profile
+is taken, enabling historical comparison via the diff engine.
+
+Schema
+------
+.. code-block:: sql
+
+    CREATE TABLE snapshots (
+        id           INTEGER PRIMARY KEY,
+        source_db    TEXT,
+        table_name   TEXT,
+        profiled_at  TIMESTAMP,
+        profile_json TEXT   -- full TableProfile as JSON
+    );
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .models import ColumnProfile, TableProfile
+
+# Default location for the snapshot database
+_DEFAULT_DB = Path.home() / ".dqm" / "snapshots.db"
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS snapshots (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_db    TEXT        NOT NULL,
+    table_name   TEXT        NOT NULL,
+    profiled_at  TIMESTAMP   NOT NULL,
+    profile_json TEXT        NOT NULL
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _open(db_path: Path = _DEFAULT_DB) -> sqlite3.Connection:
+    """Open (and initialise if needed) the SQLite snapshot database."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute(_DDL)
+    conn.commit()
+    return conn
+
+
+def _profile_to_json(profile: TableProfile) -> str:
+    """Serialise a TableProfile to a JSON string."""
+
+    def _default(obj: Any) -> Any:
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return str(obj)
+
+    return json.dumps(asdict(profile), default=_default)
+
+
+def _json_to_profile(raw: str) -> TableProfile:
+    """Deserialise a JSON string back into a TableProfile."""
+    data = json.loads(raw)
+
+    columns = [
+        ColumnProfile(
+            name=col["name"],
+            dtype=col["dtype"],
+            row_count=col["row_count"],
+            null_count=col["null_count"],
+            null_pct=col["null_pct"],
+            unique_count=col["unique_count"],
+            min_val=col["min_val"],
+            max_val=col["max_val"],
+            mean=col["mean"],
+            p25=col["p25"],
+            p75=col["p75"],
+            top_values=[tuple(v) for v in col["top_values"]],
+        )
+        for col in data.get("columns", [])
+    ]
+
+    profiled_at_raw = data.get("profiled_at", "")
+    try:
+        profiled_at = datetime.fromisoformat(profiled_at_raw)
+    except (ValueError, TypeError):
+        profiled_at = datetime.now(tz=timezone.utc)
+
+    return TableProfile(
+        table=data["table"],
+        db_path=data.get("db_path", ""),
+        profiled_at=profiled_at,
+        columns=columns,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def save_snapshot(profile: TableProfile, snapshots_db: Path = _DEFAULT_DB) -> int:
+    """Persist *profile* and return the new snapshot id.
+
+    Parameters
+    ----------
+    profile:
+        The :class:`~dqm.models.TableProfile` returned by the profiler.
+    snapshots_db:
+        Path to the SQLite snapshot store (defaults to ``~/.dqm/snapshots.db``).
+
+    Returns
+    -------
+    int
+        The ``id`` of the newly inserted row.
+    """
+    conn = _open(snapshots_db)
+    try:
+        cursor = conn.execute(
+            "INSERT INTO snapshots (source_db, table_name, profiled_at, profile_json) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                profile.db_path,
+                profile.table,
+                profile.profiled_at.isoformat(),
+                _profile_to_json(profile),
+            ),
+        )
+        conn.commit()
+        return cursor.lastrowid  # type: ignore[return-value]
+    finally:
+        conn.close()
+
+
+def list_snapshots(
+    table_name: str,
+    snapshots_db: Path = _DEFAULT_DB,
+) -> list[dict[str, Any]]:
+    """Return snapshot history for *table_name*, newest first.
+
+    Each entry is a dict with keys: ``id``, ``source_db``, ``table_name``,
+    ``profiled_at`` (ISO string).
+    """
+    conn = _open(snapshots_db)
+    try:
+        rows = conn.execute(
+            "SELECT id, source_db, table_name, profiled_at "
+            "FROM snapshots "
+            "WHERE table_name = ? "
+            "ORDER BY profiled_at DESC",
+            (table_name,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_snapshot(snapshot_id: int, snapshots_db: Path = _DEFAULT_DB) -> TableProfile | None:
+    """Fetch a single snapshot by *id* and deserialise it.
+
+    Returns ``None`` if no snapshot with that id exists.
+    """
+    conn = _open(snapshots_db)
+    try:
+        row = conn.execute(
+            "SELECT profile_json FROM snapshots WHERE id = ?",
+            (snapshot_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return _json_to_profile(row["profile_json"])
+    finally:
+        conn.close()
+
+
+def get_latest_two_snapshots(
+    table_name: str,
+    snapshots_db: Path = _DEFAULT_DB,
+) -> tuple[TableProfile, TableProfile] | None:
+    """Return (before, after) — the two most recent snapshots for *table_name*.
+
+    Returns ``None`` if fewer than two snapshots exist.
+    """
+    conn = _open(snapshots_db)
+    try:
+        rows = conn.execute(
+            "SELECT profile_json FROM snapshots "
+            "WHERE table_name = ? "
+            "ORDER BY profiled_at DESC "
+            "LIMIT 2",
+            (table_name,),
+        ).fetchall()
+        if len(rows) < 2:
+            return None
+        # rows[0] = newest (after), rows[1] = second newest (before)
+        after = _json_to_profile(rows[0]["profile_json"])
+        before = _json_to_profile(rows[1]["profile_json"])
+        return before, after
+    finally:
+        conn.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "anthropic>=0.84.0",
     "click>=8.3.1",
     "duckdb>=1.4.4",
+    "pyyaml>=6.0",
     "rich>=14.3.3",
 ]
 

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -1,0 +1,359 @@
+"""Tests for dqm.anomaly — AnomalyDetector rule-based checks."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from dqm.anomaly import AnomalyDetector
+from dqm.models import Anomaly, ColumnProfile, TableProfile
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 3, 8, tzinfo=timezone.utc)
+
+
+def _make_col(
+    name: str = "col",
+    row_count: int = 1000,
+    null_pct: float = 0.01,
+    unique_count: int = 500,
+    min_val: float | None = 1.0,
+    max_val: float | None = 100.0,
+    dtype: str = "DOUBLE",
+) -> ColumnProfile:
+    null_count = int(null_pct * row_count)
+    return ColumnProfile(
+        name=name,
+        dtype=dtype,
+        row_count=row_count,
+        null_count=null_count,
+        null_pct=null_pct,
+        unique_count=unique_count,
+        min_val=min_val,
+        max_val=max_val,
+        mean=None,
+        p25=None,
+        p75=None,
+        top_values=[],
+    )
+
+
+def _make_profile(
+    table: str = "episodes",
+    columns: list[ColumnProfile] | None = None,
+) -> TableProfile:
+    if columns is None:
+        columns = [_make_col()]
+    return TableProfile(table=table, db_path=":memory:", profiled_at=_NOW, columns=columns)
+
+
+@pytest.fixture
+def detector() -> AnomalyDetector:
+    return AnomalyDetector()
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: null_pct_increase — ALERT when delta > 10 pp
+# ---------------------------------------------------------------------------
+
+
+def test_null_pct_increase_triggers_alert(detector):
+    before = _make_profile(columns=[_make_col("title", null_pct=0.01)])
+    after = _make_profile(columns=[_make_col("title", null_pct=0.15)])  # +14 pp
+    anomalies = detector.detect(before, after)
+    assert any(a.rule_triggered == "null_pct_increase" and a.severity == "ALERT" for a in anomalies)
+
+
+def test_null_pct_increase_column_name(detector):
+    before = _make_profile(columns=[_make_col("body", null_pct=0.00)])
+    after = _make_profile(columns=[_make_col("body", null_pct=0.50)])
+    anomalies = detector.detect(before, after)
+    alert = next(a for a in anomalies if a.rule_triggered == "null_pct_increase")
+    assert alert.column == "body"
+
+
+def test_null_pct_increase_values(detector):
+    before = _make_profile(columns=[_make_col("score", null_pct=0.05)])
+    after = _make_profile(columns=[_make_col("score", null_pct=0.30)])
+    anomalies = detector.detect(before, after)
+    alert = next(a for a in anomalies if a.rule_triggered == "null_pct_increase")
+    assert alert.old_val == pytest.approx(5.0)
+    assert alert.new_val == pytest.approx(30.0)
+
+
+def test_null_pct_increase_no_alert_below_threshold(detector):
+    before = _make_profile(columns=[_make_col("score", null_pct=0.01)])
+    after = _make_profile(columns=[_make_col("score", null_pct=0.05)])  # +4 pp — below 10 pp
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "null_pct_increase" for a in anomalies)
+
+
+def test_null_pct_decrease_does_not_trigger(detector):
+    before = _make_profile(columns=[_make_col("score", null_pct=0.30)])
+    after = _make_profile(columns=[_make_col("score", null_pct=0.01)])
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "null_pct_increase" for a in anomalies)
+
+
+def test_null_pct_exactly_at_threshold_no_alert(detector):
+    """Exactly 10 pp — rule uses strictly-greater-than."""
+    before = _make_profile(columns=[_make_col("x", null_pct=0.00)])
+    after = _make_profile(columns=[_make_col("x", null_pct=0.10)])  # exactly 10 pp
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "null_pct_increase" for a in anomalies)
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: unique_count_drop — WARN when drop > 20 %
+# ---------------------------------------------------------------------------
+
+
+def test_unique_count_drop_triggers_warn(detector):
+    before = _make_profile(columns=[_make_col("model", unique_count=100)])
+    after = _make_profile(columns=[_make_col("model", unique_count=50)])  # -50 %
+    anomalies = detector.detect(before, after)
+    assert any(a.rule_triggered == "unique_count_drop" and a.severity == "WARN" for a in anomalies)
+
+
+def test_unique_count_drop_values(detector):
+    before = _make_profile(columns=[_make_col("model", unique_count=200)])
+    after = _make_profile(columns=[_make_col("model", unique_count=100)])
+    anomalies = detector.detect(before, after)
+    warn = next(a for a in anomalies if a.rule_triggered == "unique_count_drop")
+    assert warn.old_val == pytest.approx(200.0)
+    assert warn.new_val == pytest.approx(100.0)
+
+
+def test_unique_count_drop_no_warn_below_threshold(detector):
+    before = _make_profile(columns=[_make_col("model", unique_count=100)])
+    after = _make_profile(columns=[_make_col("model", unique_count=90)])  # -10 % — fine
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "unique_count_drop" for a in anomalies)
+
+
+def test_unique_count_drop_no_trigger_when_zero_before(detector):
+    before = _make_profile(columns=[_make_col("model", unique_count=0)])
+    after = _make_profile(columns=[_make_col("model", unique_count=0)])
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "unique_count_drop" for a in anomalies)
+
+
+def test_unique_count_increase_does_not_trigger(detector):
+    before = _make_profile(columns=[_make_col("model", unique_count=100)])
+    after = _make_profile(columns=[_make_col("model", unique_count=200)])
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "unique_count_drop" for a in anomalies)
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: row_count_decrease — ALERT when rows decreased
+# ---------------------------------------------------------------------------
+
+
+def test_row_count_decrease_triggers_alert(detector):
+    before = _make_profile(columns=[_make_col(row_count=1000)])
+    after = _make_profile(columns=[_make_col(row_count=800)])
+    anomalies = detector.detect(before, after)
+    assert any(a.rule_triggered == "row_count_decrease" and a.severity == "ALERT" for a in anomalies)
+
+
+def test_row_count_decrease_values(detector):
+    before = _make_profile(columns=[_make_col(row_count=5000)])
+    after = _make_profile(columns=[_make_col(row_count=1000)])
+    anomalies = detector.detect(before, after)
+    a = next(x for x in anomalies if x.rule_triggered == "row_count_decrease")
+    assert a.old_val == 5000.0
+    assert a.new_val == 1000.0
+    assert a.column == "__table__"
+
+
+def test_row_count_stable_does_not_trigger(detector):
+    before = _make_profile(columns=[_make_col(row_count=1000)])
+    after = _make_profile(columns=[_make_col(row_count=1000)])
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "row_count_decrease" for a in anomalies)
+
+
+def test_row_count_increase_does_not_trigger_decrease_rule(detector):
+    before = _make_profile(columns=[_make_col(row_count=1000)])
+    after = _make_profile(columns=[_make_col(row_count=1100)])
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "row_count_decrease" for a in anomalies)
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: row_count_spike — WARN when rows increased > 500 %
+# ---------------------------------------------------------------------------
+
+
+def test_row_count_spike_triggers_warn(detector):
+    before = _make_profile(columns=[_make_col(row_count=1000)])
+    after = _make_profile(columns=[_make_col(row_count=7000)])  # +600 %
+    anomalies = detector.detect(before, after)
+    assert any(a.rule_triggered == "row_count_spike" and a.severity == "WARN" for a in anomalies)
+
+
+def test_row_count_spike_exactly_at_threshold_no_warn(detector):
+    """Exactly 6× (500 % increase) sits right at the boundary (not over)."""
+    before = _make_profile(columns=[_make_col(row_count=1000)])
+    after = _make_profile(columns=[_make_col(row_count=6000)])  # exactly 6× = 500 % more
+    anomalies = detector.detect(before, after)
+    # At exactly 6× (1 + 5.00) there is no spike — must be strictly greater
+    assert not any(a.rule_triggered == "row_count_spike" for a in anomalies)
+
+
+def test_row_count_modest_increase_no_warn(detector):
+    before = _make_profile(columns=[_make_col(row_count=1000)])
+    after = _make_profile(columns=[_make_col(row_count=1500)])  # +50 %
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "row_count_spike" for a in anomalies)
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: max_val_decrease — ALERT for monotonic columns
+# ---------------------------------------------------------------------------
+
+
+def test_max_val_decrease_triggers_alert():
+    detector = AnomalyDetector()
+    # Manually set the monotonic columns list
+    detector._monotonic_columns = ["id"]
+    before = _make_profile(columns=[_make_col("id", max_val=1000.0)])
+    after = _make_profile(columns=[_make_col("id", max_val=900.0)])
+    anomalies = detector.detect(before, after)
+    assert any(a.rule_triggered == "max_val_decrease" and a.severity == "ALERT" for a in anomalies)
+
+
+def test_max_val_decrease_values():
+    detector = AnomalyDetector()
+    detector._monotonic_columns = ["id"]
+    before = _make_profile(columns=[_make_col("id", max_val=500.0)])
+    after = _make_profile(columns=[_make_col("id", max_val=100.0)])
+    anomalies = detector.detect(before, after)
+    a = next(x for x in anomalies if x.rule_triggered == "max_val_decrease")
+    assert a.old_val == pytest.approx(500.0)
+    assert a.new_val == pytest.approx(100.0)
+
+
+def test_max_val_increase_does_not_trigger():
+    detector = AnomalyDetector()
+    detector._monotonic_columns = ["id"]
+    before = _make_profile(columns=[_make_col("id", max_val=100.0)])
+    after = _make_profile(columns=[_make_col("id", max_val=200.0)])
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "max_val_decrease" for a in anomalies)
+
+
+def test_max_val_not_checked_for_non_monotonic_column(detector):
+    before = _make_profile(columns=[_make_col("score", max_val=100.0)])
+    after = _make_profile(columns=[_make_col("score", max_val=50.0)])
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "max_val_decrease" for a in anomalies)
+
+
+def test_max_val_decrease_non_numeric_skipped():
+    detector = AnomalyDetector()
+    detector._monotonic_columns = ["name"]
+    before = _make_profile(columns=[_make_col("name", max_val="zoo", min_val="aardvark", dtype="VARCHAR")])
+    after = _make_profile(columns=[_make_col("name", max_val="alpha", min_val="aardvark", dtype="VARCHAR")])
+    # Strings are non-numeric → should not raise, just skip
+    anomalies = detector.detect(before, after)
+    # may or may not fire depending on float() cast — the point is no exception
+    assert isinstance(anomalies, list)
+
+
+# ---------------------------------------------------------------------------
+# Anomaly model / backward-compat properties
+# ---------------------------------------------------------------------------
+
+
+def test_anomaly_metric_alias():
+    a = Anomaly(column="x", rule_triggered="null_pct_increase", old_val=5.0, new_val=20.0, severity="ALERT")
+    assert a.metric == "null_pct_increase"
+
+
+def test_anomaly_value_aliases():
+    a = Anomaly(column="x", rule_triggered="row_count_decrease", old_val=1000.0, new_val=500.0, severity="ALERT")
+    assert a.value_before == 1000.0
+    assert a.value_after == 500.0
+
+
+def test_anomaly_delta_pp():
+    a = Anomaly(column="x", rule_triggered="null_pct_increase", old_val=5.0, new_val=20.0, severity="ALERT")
+    assert a.delta_pp == pytest.approx(15.0)
+
+
+# ---------------------------------------------------------------------------
+# Configurable thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_custom_threshold_via_config(tmp_path):
+    """Lower the null_pct_increase threshold to 5 pp via a YAML config file."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("thresholds:\n  null_pct_increase_pp: 5.0\n")
+    detector = AnomalyDetector(config_path=cfg)
+
+    before = _make_profile(columns=[_make_col("x", null_pct=0.00)])
+    after = _make_profile(columns=[_make_col("x", null_pct=0.07)])  # +7 pp > 5 pp
+    anomalies = detector.detect(before, after)
+    assert any(a.rule_triggered == "null_pct_increase" for a in anomalies)
+
+
+def test_custom_threshold_no_alert_with_strict_threshold(tmp_path):
+    """Raise the null_pct_increase threshold to 20 pp — 12 pp should not fire."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("thresholds:\n  null_pct_increase_pp: 20.0\n")
+    detector = AnomalyDetector(config_path=cfg)
+
+    before = _make_profile(columns=[_make_col("x", null_pct=0.00)])
+    after = _make_profile(columns=[_make_col("x", null_pct=0.12)])  # +12 pp < 20 pp
+    anomalies = detector.detect(before, after)
+    assert not any(a.rule_triggered == "null_pct_increase" for a in anomalies)
+
+
+def test_monotonic_columns_from_yaml_config(tmp_path):
+    """Pass monotonic_columns list via YAML config."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("thresholds:\n  monotonic_columns:\n    - episode_id\n")
+    detector = AnomalyDetector(config_path=cfg)
+    assert "episode_id" in detector._monotonic_columns
+
+
+# ---------------------------------------------------------------------------
+# Multiple anomalies in one detect() call
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_anomalies_same_table():
+    detector = AnomalyDetector()
+    before = _make_profile(
+        columns=[
+            _make_col("title", null_pct=0.01, unique_count=900, row_count=1000),
+            _make_col("score", null_pct=0.00, unique_count=500, row_count=1000),
+        ]
+    )
+    after = _make_profile(
+        columns=[
+            _make_col("title", null_pct=0.50, unique_count=50, row_count=500),  # both null + unique fire
+            _make_col("score", null_pct=0.00, unique_count=500, row_count=500),
+        ]
+    )
+    anomalies = detector.detect(before, after)
+    rules = [a.rule_triggered for a in anomalies]
+    assert "null_pct_increase" in rules
+    assert "unique_count_drop" in rules
+    assert "row_count_decrease" in rules
+
+
+def test_no_anomalies_clean_data(detector):
+    before = _make_profile(columns=[_make_col(row_count=1000, null_pct=0.01, unique_count=500)])
+    after = _make_profile(columns=[_make_col(row_count=1010, null_pct=0.01, unique_count=505)])
+    anomalies = detector.detect(before, after)
+    assert anomalies == []

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -81,6 +81,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "click" },
     { name = "duckdb" },
+    { name = "pyyaml" },
     { name = "rich" },
 ]
 
@@ -94,6 +95,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "duckdb", specifier = ">=1.4.4" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=14.3.3" },
 ]
 
@@ -418,6 +420,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements issue #8: rule-based anomaly detection with configurable thresholds, a snapshot store, a diff engine, and the `dqm check <table>` CLI command.

## Changes

### New files
- **`dqm/anomaly.py`** — `AnomalyDetector` class with 5 built-in rules
- **`dqm/anomaly_config.yaml`** — bundled default thresholds (YAML)
- **`dqm/snapshots.py`** — SQLite-backed snapshot store (`~/.dqm/snapshots.db`)
- **`dqm/diff.py`** — diff engine comparing two `TableProfile` snapshots
- **`tests/test_anomaly.py`** — 31 new tests (82 total, all green)

### Modified files
- **`dqm/models.py`** — extended `Anomaly` class with `rule_triggered`/`old_val`/`new_val` fields; backward-compat with legacy `metric`/`value_before`/`value_after`/`delta_pp`; extended `ColumnDiff` with `row_count_before/after`, `min/max_before/after`
- **`dqm/cli.py`** — added `dqm check <table>` command
- **`pyproject.toml`** — added `pyyaml>=6.0` dependency
- **`README.md`** — documented `check` command, rules table, config example

## Default rules

| Rule | Condition | Severity |
|------|-----------|----------|
| `null_pct_increase` | null % rose by > 10 pp | **ALERT** |
| `unique_count_drop` | unique count fell by > 20 % | **WARN** |
| `row_count_decrease` | row count decreased at all | **ALERT** |
| `row_count_spike` | row count increased by > 500 % | **WARN** |
| `max_val_decrease` | max value fell for a monotonic column | **ALERT** |

## Acceptance criteria

Manually injected: 5 clean rows → 50 rows with 80 % null titles.

`dqm check episodes` correctly flagged:
- **ALERT** `null_pct_increase` on `title` (0 % → 80 %, +80 pp)
- **WARN** `row_count_spike` on `__table__` (5 → 50 rows, +900 %)

Closes #8